### PR TITLE
Add helper classes for upgrade tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,12 +4,12 @@
 import logging
 import os
 import os.path
-import subprocess
 from pytest import Config, FixtureRequest, Parser, fixture
 from typing import Generator
 from utils.device import (
     Device, UsbDevice, generate_serial, state_dir, spawn_device
 )
+from utils.subprocess import check_output
 
 
 logger = logging.getLogger(__name__)
@@ -31,9 +31,7 @@ def pytest_report_header(config: Config) -> str:
     def get_version(binary: str) -> str:
         path = os.path.join("bin", binary)
         if os.path.exists(path):
-            version = "v" + subprocess.check_output(
-                [path, "--version"], encoding="utf-8"
-            ).split()[1]
+            version = "v" + check_output([path, "--version"]).split()[1]
         else:
             version = "[missing]"
         return version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,5 @@ requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
 
 [tool.pytest.ini_options]
-addopts = "--strict-markers"
+addopts = "--strict-markers --verbose"
 markers = ["virtual"]

--- a/test_basic.py
+++ b/test_basic.py
@@ -1,15 +1,13 @@
 # Copyright (C) 2022 Nitrokey GmbH
 # SPDX-License-Identifier: CC0-1.0
 
-import subprocess
 from pexpect import spawn
 from utils.fido2 import Fido2
+from utils.subprocess import check_output
 
 
 def test_lsusb(device) -> None:
-    devices = subprocess.check_output(
-        ["lsusb", "-d", "20a0:42b2"]
-    ).splitlines()
+    devices = check_output(["lsusb", "-d", "20a0:42b2"]).splitlines()
     assert len(devices) == 1
 
 

--- a/test_basic.py
+++ b/test_basic.py
@@ -1,9 +1,11 @@
 # Copyright (C) 2022 Nitrokey GmbH
 # SPDX-License-Identifier: CC0-1.0
 
+from contextlib import contextmanager
 from pexpect import spawn
 from utils.fido2 import Fido2
 from utils.subprocess import check_output
+from utils.upgrade import ExecUpgradeTest
 
 
 def test_lsusb(device) -> None:
@@ -18,11 +20,18 @@ def test_list(device) -> None:
     # TODO: assert that there are no other keys
 
 
-def test_fido2(device) -> None:
-    fido2 = Fido2(device.hidraw)
-    credential = fido2.register(b"user_id", "A. User")
-    fido2.authenticate([credential])
+class TestFido2(ExecUpgradeTest):
     # TODO:
     # - Test server with non-registered client
     # - Test client with non-registered server
     # - Test with multiple credentials
+
+    @contextmanager
+    def context(self, device):
+        yield Fido2(device.hidraw)
+
+    def prepare(self, fido2):
+        return fido2.register(b"user_id", "A. User")
+
+    def verify(self, fido2, credential):
+        fido2.authenticate([credential])

--- a/test_upgrade.py
+++ b/test_upgrade.py
@@ -1,19 +1,20 @@
 # Copyright (C) 2022 Nitrokey GmbH
 # SPDX-License-Identifier: CC0-1.0
 
+# Tests in this module may not use the device fixture!
+
 import pytest
-from utils.device import spawn_device
-from utils.fido2 import Fido2
+from utils.upgrade import ExecUpgradeTest
+from typing import Type
 
 
-pytestmark = pytest.mark.skipif("not config.getoption('upgrade')")
+pytestmark = pytest.mark.skipif(
+    "not config.getoption('upgrade')",
+    reason="--upgrade not set",
+)
 
 
+@pytest.mark.parametrize("test", ExecUpgradeTest.__subclasses__())
 @pytest.mark.virtual
-def test_upgrade_fido2(serial: str, ifs: str) -> None:
-    with spawn_device(serial=serial, ifs=ifs, suffix="old") as device:
-        fido2 = Fido2(device.hidraw)
-        credential = fido2.register(b"user_id", "A. User")
-    with spawn_device(serial=serial, ifs=ifs, provision=False) as device:
-        fido2 = Fido2(device.hidraw)
-        fido2.authenticate([credential])
+def test(test: Type[ExecUpgradeTest], serial: str, ifs: str) -> None:
+    test().run_upgrade(serial, ifs)

--- a/utils/device.py
+++ b/utils/device.py
@@ -174,6 +174,8 @@ def find_devices(vid: int, pid: int) -> List[str]:
 
 def find_device(vid: int, pid: int) -> str:
     devices = find_devices(vid, pid)
+    if not devices:
+        raise RuntimeError("no matching device found")
     if len(devices) > 1:
         raise RuntimeError(f"{len(devices)} devices connected: {devices}")
     return devices[0]

--- a/utils/device.py
+++ b/utils/device.py
@@ -5,7 +5,6 @@ import logging
 import os
 import os.path
 import random
-import subprocess
 import time
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
@@ -13,6 +12,7 @@ from fido2.hid import open_device
 from subprocess import Popen
 from tempfile import TemporaryDirectory, mkdtemp
 from typing import Any, Generator, List, Optional
+from .subprocess import check_call, check_output
 
 
 logger = logging.getLogger(__name__)
@@ -53,7 +53,7 @@ class UsbipDevice(Device):
 
     def provision(self) -> None:
         logger.debug("Provisioning usbip-runner")
-        subprocess.check_call(
+        check_call(
             [
                 "nitropy",
                 "nk3",
@@ -68,7 +68,7 @@ class UsbipDevice(Device):
 
     @staticmethod
     def spawn(binary: str, serial: str, ifs: str) -> "UsbipDevice":
-        mods = subprocess.check_output(["lsmod"], encoding="utf-8")
+        mods = check_output(["lsmod"])
         mod_lines = mods.splitlines()
         if not any([line.startswith("vhci_hcd") for line in mod_lines]):
             raise RuntimeError(
@@ -88,9 +88,9 @@ class UsbipDevice(Device):
         )
 
         host = "localhost"
-        subprocess.check_call(["usbip", "list", "-r", host])
-        subprocess.check_call(["usbip", "attach", "-r", host, "-b", "1-1"])
-        subprocess.check_call(["usbip", "attach", "-r", host, "-b", "1-1"])
+        check_call(["usbip", "list", "-r", host])
+        check_call(["usbip", "attach", "-r", host, "-b", "1-1"])
+        check_call(["usbip", "attach", "-r", host, "-b", "1-1"])
 
         for i in range(5):
             if not find_devices(0x20a0, 0x42b2):

--- a/utils/subprocess.py
+++ b/utils/subprocess.py
@@ -1,0 +1,12 @@
+# Copyright (C) 2022 Nitrokey GmbH
+# SPDX-License-Identifier: CC0-1.0
+
+import subprocess
+
+
+def check_call(cmd: list[str], timeout: int = 5) -> None:
+    subprocess.check_call(cmd, timeout=timeout)
+
+
+def check_output(cmd: list[str], timeout: int = 5) -> str:
+    return subprocess.check_output(cmd, encoding="utf-8", timeout=timeout)

--- a/utils/upgrade.py
+++ b/utils/upgrade.py
@@ -1,0 +1,61 @@
+# Copyright (C) 2022 Nitrokey GmbH
+# SPDX-License-Identifier: CC0-1.0
+
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from typing import Generator, Generic, TypeVar
+from .device import Device, spawn_device
+
+
+Context = TypeVar("Context")
+State = TypeVar("State")
+
+
+class UpgradeTest(ABC, Generic[Context, State]):
+    """
+    A test case that can be executed in two steps:  a preparation step and a
+    verification step.  The verification step does not have to be executed
+    in the same session, making it possible to reboot or upgrade the device
+    between the steps.  Both steps can use a context that is constructed
+    from the device.
+
+    The `run` and `run_upgrade` methods can be used to easily run the tests
+    with a single device or with a firmware upgrade simulation.
+    """
+    @contextmanager
+    @abstractmethod
+    def context(self, device: Device) -> Generator[Context, None, None]:
+        pass
+
+    @abstractmethod
+    def prepare(self, context: Context) -> State:
+        pass
+
+    @abstractmethod
+    def verify(self, context: Context, state: State) -> None:
+        pass
+
+    def run(self, device: Device) -> None:
+        with self.context(device) as context:
+            state = self.prepare(context)
+            self.verify(context, state)
+
+    def run_upgrade(self, serial: str, ifs: str) -> None:
+        with spawn_device(serial=serial, ifs=ifs, suffix="old") as device:
+            with self.context(device) as context:
+                state = self.prepare(context)
+        with spawn_device(serial=serial, ifs=ifs, provision=False) as device:
+            with self.context(device) as context:
+                self.verify(context, state)
+
+
+class ExecUpgradeTest(UpgradeTest[Context, State]):
+    """
+    An upgrade test that can be executed automatically because it does not need
+    additional fixtures or paremeters.  Subclasses of this class are
+    automatically executed in the declaring module using a single device, and
+    in the test_upgrade module simulating a firmware upgrade between the
+    preparation and verification steps.
+    """
+    def test(self, device: Device) -> None:
+        self.run(device)


### PR DESCRIPTION
This PR adds helper classes that make it easier two write upgrade tests.  Instead of writing the same test twice, once for a single device with the current firmware and once with a preparation step with the old firmware and a verification step with the current firmware:

```python3
def test_fido2(device) -> None:
    fido2 = Fido2(device.hidraw)
    credential = fido2.register(b"user_id", "A. User")
    fido2.authenticate([credential])

@upgrade
@pytest.mark.virtual
def test_upgrade_fido2(serial: str, ifs: str) -> None:
    with spawn_device(serial=serial, ifs=ifs, suffix="old") as device:
        fido2 = Fido2(device.hidraw)
        credential = fido2.register(b"user_id", "A. User")
    with spawn_device(serial=serial, ifs=ifs, provision=False) as device:
        fido2 = Fido2(device.hidraw)
        fido2.authenticate([credential])
```

We can now write it only once:

```python3
class TestFido2(ExecUpgradeTest):
    @contextmanager
    def context(self, device):
        yield Fido2(device.hidraw)

    def prepare(self, fido2):
        return fido2.register(b"user_id", "A. User")

    def run(self, fido2, credential):
        fido2.authenticate([credential])
```

This will automatically generate two test functions like these:

```python3
    def test_exec(self, device: Device) -> None:
        with self.context(device) as context:
            state = self.prepare(context)
            self.run(context, state)

    @upgrade
    @pytest.mark.virtual
    def test_exec_upgrade(self, serial: str, ifs: str) -> None:
        with spawn_device(serial=serial, ifs=ifs, suffix="old") as device:
            with self.context(device) as context:
                state = self.prepare(context)
        with spawn_device(serial=serial, ifs=ifs, provision=False) as device:
            with self.context(device) as context:
                self.run(context, state)
```

The big advantage of this approach is that we can easily test upgrade stability and data retention for all features.  The downside is that we have to change the scope of the `device` fixture from module to function because the upgrade tests are no longer in a separate module.  That means we have to spawn a new virtual  device for every test function, adding an overhead of up to five seconds per test.

Which way do you prefer?  Or do you have any ideas how to avoid the overhead?