### PR TITLE
Add test-release.sh script to test GitHub releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,17 @@ Make sure that the `vhci-hcd` kernel module is loaded:
 # lsmod | grep vhci_hcd || modprobe vhci-hcd
 ```
 
-Use the `test-local.sh` script to compile the usbip runner from a local Git checkout of the [`nitrokey-3-firmware`][] repository and to execute all tests for it:
+Use the `test-release.sh` script to download and test the usbip binaries from a GitHub release of the [`nitrokey-3-firmware`][] repository:
+```
+$ ./test-release.sh v1.3.0-rc.1
+```
+
+If you pass a second version, it will also run upgrade tests from that version:
+```
+$ ./test-release.sh v1.3.0-rc.1 v1.2.2-alpha.20230224
+```
+
+Use the `test-local.sh` script to compile the usbip runner from a local Git checkout of the [`nitrokey-3-firmware`][] repository instead:
 ```
 $ ./test-local.sh ../nitrokey-3-firmware
 ```

--- a/test-release.sh
+++ b/test-release.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Copyright (C) 2023 Nitrokey GmbH
+# SPDX-License-Identifier: CC0-1.0
+
+set -o errexit
+
+if [ \( $# -eq 0 \) -o \( $# -gt 2 \) ]
+then
+	echo "Usage: $0 tag [upgrade_from]" >&2
+	echo "" >&2
+	echo "Download the usbip runner for the given release and execute the " >&2
+	echo "tests using it." >&2
+	echo "If upgrade_from is set, also execute upgrade tests using the given release" >&2
+	echo "as the baseline." >&2
+	exit 1
+fi
+
+tag=$1
+
+mkdir -p bin
+
+runner=`echo $tag | grep --quiet alpha && echo alpha || echo runner`
+curl --silent --location "https://github.com/Nitrokey/nitrokey-3-firmware/releases/download/$tag/usbip-$runner-$tag" --output bin/usbip-runner
+curl --silent --location "https://github.com/Nitrokey/nitrokey-3-firmware/releases/download/$tag/usbip-provisioner-$tag" --output bin/usbip-provisioner
+
+if [ $# -eq 2 ]
+then
+	upgrade_from=$2
+
+	runner=`echo $upgrade_from | grep --quiet alpha && echo alpha || echo runner`
+	curl --silent --location "https://github.com/Nitrokey/nitrokey-3-firmware/releases/download/$upgrade_from/usbip-$runner-$upgrade_from" --output bin/usbip-runner-old
+	curl --silent --location "https://github.com/Nitrokey/nitrokey-3-firmware/releases/download/$upgrade_from/usbip-provisioner-$upgrade_from" --output bin/usbip-provisioner-old
+
+	export PYTEST_FLAGS="--upgrade"
+fi
+
+make run-docker


### PR DESCRIPTION
This patch adds the test-release.sh script that downloads usbip binaries from GitHub releases and executes the tests using these binaries.

```
$ ./test-release.sh v1.3.0-rc.1
$ ./test-release.sh v1.3.0-rc.1 v1.2.2-alpha.20230224
```