### PR TITLE
Add basic OTP tests using the secrets app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@
 fido2 >=1.1,<2
 pexpect >=4,<5
 # pynitrokey ==0.4.31
-git+https://github.com/nitrokey/pynitrokey@0e8bf844fd764807828cb6539e519170d5bb0be5#egg=pynitrokey
+git+https://github.com/nitrokey/pynitrokey@e40f91a4232b09cbb6c92740f650b9c170da7033#egg=pynitrokey
 pytest >=7,<8

--- a/stubs/pexpect.pyi
+++ b/stubs/pexpect.pyi
@@ -1,11 +1,18 @@
 # Copyright (C) 2022 Nitrokey GmbH
 # SPDX-License-Identifier: CC0-1.0
 
+from typing import Union
+
+
+class EOF:
+    ...
+
+
 class spawn:
     def __init__(self, cmd: str, args: list[str] = [], timeout: int = 30) -> None:
         pass
 
-    def expect(self, s: str) -> None:
+    def expect(self, s: Union[str, EOF]) -> None:
         pass
 
     def sendline(self, s: str) -> None:

--- a/tests/upgrade.py
+++ b/tests/upgrade.py
@@ -28,6 +28,11 @@ def test_fido2_resident(serial: str, ifs: str) -> None:
 
 
 @pytest.mark.virtual
+def test_secrets_resident(serial: str, ifs: str) -> None:
+    tests.basic.TestSecrets().run_upgrade(serial, ifs)
+
+
+@pytest.mark.virtual
 @pytest.mark.parametrize("type", SSH_KEY_TYPES)
 def test_ssh(serial: str, ifs: str, type: str) -> None:
     tests.basic.TestSsh(type).run_upgrade(serial, ifs)


### PR DESCRIPTION
This patch adds basic tests for the HOTP and TOTP functionality of the secrets app.  It uses the test vectors from the respective RFCs.

Fixes https://github.com/Nitrokey/nitrokey-3-tests/issues/16