### PR TITLE
add reset tests - for a clean (hw) device

### DIFF
--- a/tests/basic.py
+++ b/tests/basic.py
@@ -28,6 +28,20 @@ def test_list(device) -> None:
     # TODO: assert that there are no other keys
 
 
+def test_reset_fido2(device) -> None:
+    p = spawn("nitropy fido2 reset")
+    p.expect("continue?")
+    p.sendline("y")
+    p.expect("....aaaand they're gone")
+
+
+def test_reset_secrets(device) -> None:
+    p = spawn("nitropy nk3 secrets reset")
+    p.expect("continue?")
+    p.sendline("y")
+    p.expect("Operation executed")
+
+
 class TestFido2(ExecUpgradeTest):
     # TODO:
     # - Test server with non-registered client


### PR DESCRIPTION
* add `test_reset_fido2`
* add `test_reset_secrets`
* <del>add sleep(2) before set-pin & before RKs::verify to ensure last operation is finished (to be improved)</del>

This runs best with a `develop-no-press` firmware image, then the entire test-suite runs unattended. Without any logging `log-rtt` activated the test-suite works without any added sleeps...