### PR TITLE
Add touch button support

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -70,6 +70,20 @@ def device(request: FixtureRequest) -> Generator[Device, None, None]:
                 yield device
 
 
+@fixture(scope="module")
+def touch_device(request: FixtureRequest) -> Generator[Device, None, None]:
+    serials = request.config.getoption("--use-usb-devices")
+    if serials:
+        yield UsbDevice.find(serials)
+    else:
+        keep_state = request.config.getoption("--keep-state")
+        with state_dir(keep_state) as s:
+            ifs = os.path.join(s, "ifs.bin")
+            efs = os.path.join(s, "efs.bin")
+            with spawn_device(ifs, efs, user_presence=True) as device:
+                yield device
+
+
 @fixture
 def ifs(request: FixtureRequest) -> Generator[str, None, None]:
     keep_state = request.config.getoption("--keep-state")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,9 @@
 
 fido2 >=1.1,<2
 pexpect >=4,<5
-# pynitrokey ==0.4.31
-git+https://github.com/nitrokey/pynitrokey@e40f91a4232b09cbb6c92740f650b9c170da7033#egg=pynitrokey
+pynitrokey ==0.4.38
 pytest >=7,<8
+
+# pyyaml is broken with cython 3
+# see https://github.com/yaml/pyyaml/issues/724
+pyyaml !=6.0.0,!=5.4.0,!=5.4.1

--- a/stubs/pexpect.pyi
+++ b/stubs/pexpect.pyi
@@ -9,11 +9,16 @@ class EOF:
 
 
 class spawn:
-    def __init__(self, cmd: str, args: list[str] = [], timeout: int = 30) -> None:
+    def __init__(
+        self,
+        cmd: str,
+        args: list[str] = [],
+        timeout: int = 30,
+    ) -> None:
         pass
 
-    def expect(self, s: Union[str, EOF]) -> None:
+    def expect(self, s: Union[str, EOF, list[str]]) -> int:
         pass
 
-    def sendline(self, s: str) -> None:
+    def sendline(self, s: str = "") -> None:
         pass

--- a/tests/touch.py
+++ b/tests/touch.py
@@ -1,0 +1,12 @@
+# Copyright (C) 2022 Nitrokey GmbH
+# SPDX-License-Identifier: CC0-1.0
+
+from .basic import TestFido2, TestFido2Resident
+
+
+def test_fido2(touch_device):
+    TestFido2().run(touch_device)
+
+
+def test_fido2_resident(touch_device):
+    TestFido2Resident().run(touch_device)


### PR DESCRIPTION
This patch adds support for the new signal-based touch button mechanism of the usbip runner, see:
	https://github.com/Nitrokey/nitrokey-3-firmware/pull/326

As not all tests are ready to use this mechanism yet, the device fixture keeps the old behavior (just accepting all requests).  The new touch_device fixture enables the signal mechanism.  Note that you cannot use both fixtures in the same module as they both use the module scope.