### PR TITLE
Fix tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,5 @@
 
 fido2 >=1.1,<2
 pexpect >=4,<5
-pynitrokey ==0.4.38
+pynitrokey ==0.4.40
 pytest >=7,<8
-
-# pyyaml is broken with cython 3
-# see https://github.com/yaml/pyyaml/issues/724
-pyyaml !=6.0.0,!=5.4.0,!=5.4.1

--- a/tests/basic.py
+++ b/tests/basic.py
@@ -47,8 +47,8 @@ class TestFido2(UpgradeTest):
         fido2.authenticate([credential])
 
 
-def test_fido2(touch_device):
-    TestFido2().run(touch_device)
+def test_fido2(device):
+    TestFido2().run(device)
 
 
 class TestFido2Resident(UpgradeTest):
@@ -85,8 +85,8 @@ class TestFido2Resident(UpgradeTest):
         p.expect("successfully deleted")
 
 
-def test_fido2_resident(touch_device):
-    TestFido2Resident().run(touch_device)
+def test_fido2_resident(device):
+    TestFido2Resident().run(device)
 
 
 class TestSecrets(UpgradeTest):
@@ -98,7 +98,7 @@ class TestSecrets(UpgradeTest):
 
     def _spawn_with_pin(self, s):
         p = spawn(s)
-        p.expect("Current Password")
+        p.expect("Current PIN")
         p.sendline(self.pin)
         return p
 
@@ -132,14 +132,14 @@ class TestSecrets(UpgradeTest):
         p.expect("Password set")
 
         p = self._spawn_with_pin(
-            "nitropy nk3 secrets register --kind HOTP test_hotp "
-            "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
+            "nitropy nk3 secrets register --kind HOTP --protect-with-pin "
+            "test_hotp GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
         )
         p.expect(EOF)
 
         p = self._spawn_with_pin(
-            "nitropy nk3 secrets register --kind TOTP test_totp "
-            "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
+            "nitropy nk3 secrets register --kind TOTP --protect-with-pin "
+            "test_totp GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
         )
         p.expect(EOF)
 

--- a/tests/upgrade.py
+++ b/tests/upgrade.py
@@ -23,12 +23,17 @@ def test(test: Type[ExecUpgradeTest], serial: str, ifs: str, efs: str) -> None:
 
 
 @pytest.mark.virtual
+def test_fido2(serial: str, ifs: str, efs: str) -> None:
+    tests.basic.TestFido2().run_upgrade(serial, ifs, efs)
+
+
+@pytest.mark.virtual
 def test_fido2_resident(serial: str, ifs: str, efs: str) -> None:
     tests.basic.TestFido2Resident().run_upgrade(serial, ifs, efs)
 
 
 @pytest.mark.virtual
-def test_secrets_resident(serial: str, ifs: str, efs: str) -> None:
+def test_secrets(serial: str, ifs: str, efs: str) -> None:
     tests.basic.TestSecrets().run_upgrade(serial, ifs, efs)
 
 


### PR DESCRIPTION
This patch bumps pynitrokey and fixes a typo in the basic tests so that the test suite passes again when using latest trussed-usbip version, see https://github.com/Nitrokey/nitrokey-3-firmware/pull/350.