### PR TITLE
workaround: oscrypto inside venv to properly run nitropy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN python3 -m venv /venv
 RUN /venv/bin/pip install --upgrade pip --progress-bar off
 RUN /venv/bin/pip install --requirement requirements.txt --progress-bar off
 RUN /venv/bin/pip install --requirement dev-requirements.txt --progress-bar off
+RUN /venv/bin/pip install --force "oscrypto @ git+https://github.com/wbond/oscrypto.git@1547f535001ba568b239b8797465536759c742a3" --progress-bar off
 
 COPY entrypoint /
 


### PR DESCRIPTION
Current `Debian:stable` as used inside the `Dockerfile` exposes the well known libcrypto error: https://github.com/Nitrokey/pynitrokey/issues/431 

This PR would be a temporary workaround to make it work...