### PR TITLE
Adding more tests: secrets + opcard + nk3-status

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,16 @@
 
 FROM debian:stable
 
-RUN apt-get update
-RUN apt-get install --yes git kmod make openssh-client openssh-server python3 python3-venv usbip usbutils
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update --fix-missing
+RUN apt-get install --yes git kmod make openssh-client openssh-server python3 python3-venv usbip usbutils sq curl pcscd pkg-config nettle-dev libpcsclite-dev clang sqv
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup.sh
+RUN sh rustup.sh -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+RUN cargo install openpgp-card-tools --locked
 
 RUN useradd --create-home --user-group user
 

--- a/entrypoint
+++ b/entrypoint
@@ -2,5 +2,7 @@
 # Copyright (C) 2022 Nitrokey GmbH
 # SPDX-License-Identifier: CC0-1.0
 
+service pcscd start
 service ssh start
+service pcscd restart
 exec "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 
 fido2 >=1.1,<2
 pexpect >=4,<5
-pynitrokey ==0.4.40
+pynitrokey ==0.4.42
 pytest >=7,<8
 pytest-reporter-html1
 

--- a/tests/basic.py
+++ b/tests/basic.py
@@ -5,6 +5,7 @@ import os
 import pytest
 import random
 import string
+import time
 from contextlib import contextmanager
 from pexpect import EOF, spawn
 from tempfile import TemporaryDirectory
@@ -124,6 +125,9 @@ class TestSecrets(UpgradeTest):
         yield device
 
     def prepare(self, device):
+        p = spawn("nitropy nk3 secrets reset")
+        p.sendline("y")
+        p.expect("Done")
         p = spawn("nitropy nk3 secrets set-pin")
         p.expect("Password:")
         p.sendline(self.pin)

--- a/tests/basic.py
+++ b/tests/basic.py
@@ -5,8 +5,6 @@ import os
 import pytest
 import random
 import string
-import time
-import subprocess
 from contextlib import contextmanager
 from pexpect import EOF, spawn
 from tempfile import TemporaryDirectory
@@ -49,6 +47,7 @@ class TestFido2(UpgradeTest):
     def verify(self, fido2, credential):
         fido2.authenticate([credential])
 
+
 def test_fido2(device):
     TestFido2().run(device)
 
@@ -86,8 +85,10 @@ class TestFido2Resident(UpgradeTest):
         p.sendline(self.pin)
         p.expect("successfully deleted")
 
+
 def test_fido2_resident(device):
     TestFido2Resident().run(device)
+
 
 def test_nk3_status(device):
     p = spawn("nitropy nk3 status")
@@ -101,6 +102,7 @@ def test_nk3_status(device):
     p.expect("[1-9][0-9]+")
 
     p.eof()
+
 
 class TestSecrets(UpgradeTest):
     __test__ = False
@@ -252,7 +254,6 @@ def test_ssh_resident(device, type) -> None:
 
 
 def test_opcard_p256(device):
-    out = subprocess.getoutput("opgpcard list")
     card_id = f"000F:{device.serial[:8]}"
 
     p = spawn(f"opgpcard system factory-reset --card {card_id}")
@@ -274,18 +275,15 @@ def test_opcard_p256(device):
         with open(apin_path, "w") as fd:
             fd.write("12345678")
 
-        p = spawn(f"opgpcard admin -P {apin_path} --card {card_id} generate -p {upin_path} -o {pkey_path} nistp256")
+        p = spawn(f"opgpcard admin -P {apin_path} --card {card_id} "
+                  f"generate -p {upin_path} -o {pkey_path} nistp256")
         p.expect_exact("Generate subkey for Signing")
         p.expect(EOF)
 
-        p = spawn(f"opgpcard sign --card {card_id} -d -p {upin_path} -o {sig_path} {data_path}")
+        p = spawn(f"opgpcard sign --card {card_id} "
+                  f"-d -p {upin_path} -o {sig_path} {data_path}")
         p.expect(EOF)
 
-        #p = spawn("sq verify --signer-cert public-key.asc --detached data.sig input_data")
-        #p.expect_exact("Good signature from")
         p = spawn(f"sqv {sig_path} {data_path} --keyring {pkey_path} -v")
         p.expect_exact("1 of 1 signatures are valid")
         p.expect(EOF)
-
-
-

--- a/tests/basic.py
+++ b/tests/basic.py
@@ -47,7 +47,6 @@ class TestFido2(UpgradeTest):
     def verify(self, fido2, credential):
         fido2.authenticate([credential])
 
-
 def test_fido2(device):
     TestFido2().run(device)
 
@@ -85,10 +84,21 @@ class TestFido2Resident(UpgradeTest):
         p.sendline(self.pin)
         p.expect("successfully deleted")
 
-
 def test_fido2_resident(device):
     TestFido2Resident().run(device)
 
+def test_nk3_status(device):
+    p = spawn("nitropy nk3 status")
+    p.expect_exact("Init status")
+    p.expect_exact("ok")
+
+    p.expect_exact("Free blocks (int):")
+    p.expect("[1-9][0-9]+")
+
+    p.expect_exact("Free blocks (ext):")
+    p.expect("[1-9][0-9]+")
+
+    p.eof()
 
 class TestSecrets(UpgradeTest):
     __test__ = False


### PR DESCRIPTION
* install rustup inside the container to enable rust builds, i.e., `opgpcard`
* make sure that `pcscd` is up and running
* update `pynitrokey` inside container to `0.4.42`
* add `test_nk3_status` to check init status is `ok` and IFS + EFS have > 0 blocks available
* reactivate `test_secrets` by adding a `nk3 secrets reset` at the beginning to ensure a clean state 
* add `test_opcard_p256` to test key-generation, signing and verify

all this is designed to be fast an non-exhaustive - to be run on every commit